### PR TITLE
Fix tests needing a wm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       ALSOFT_CONF: resources/alsoft.conf
-      DISPLAY: 0
+      DISPLAY: :99
     steps:
     - name: Update APT
       run: sudo apt-get update
@@ -141,7 +141,8 @@ jobs:
         chmod +x love12/love12.AppImage
     - name: Start xvfb and openbox
       run: |
-        Xvfb :0 -screen 0, 360x240x24 &
+        echo "Starting XVFB on $DISPLAY"
+        Xvfb $DISPLAY -screen 0, 360x240x24 &
         echo "XVFBPID=$!" >> $GITHUB_ENV
         # wait for xvfb to startup (3s is the same amount xvfb-run waits by default)
         sleep 3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: report-test
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   macOS:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,8 @@ jobs:
       run: |
         Xvfb :0 -screen 0, 360x240x24 &
         echo "XVFBPID=$!" >> $GITHUB_ENV
+        # wait for xvfb to startup (3s is the same amount xvfb-run waits by default)
+        sleep 3
         openbox &
         echo "OPENBOXPID=$!" >> $GITHUB_ENV
     - name: Run Test Suite (opengl)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,17 +155,17 @@ jobs:
       run: |
         love12/love12.AppImage main.lua 
     - name: Love Test Report (opengl)
-       uses: ellraiser/love-test-report@main
-       with:
-         name: Love Testsuite Linux
-         title: linux-test-report-opengl
-         path: output/lovetest_runAllTests.md
-     - name: Zip Test Output (opengl)
-       run: |
-         7z a -tzip test-output-linux-opengl.zip output\
-     - name: Artifact Test Output (opengl)
-       uses: actions/upload-artifact@v3
-       with:
+      uses: ellraiser/love-test-report@main
+      with:
+        name: Love Testsuite Linux
+        title: linux-test-report-opengl
+        path: output/lovetest_runAllTests.md
+    - name: Zip Test Output (opengl)
+      run: |
+        7z a -tzip test-output-linux-opengl.zip output\
+    - name: Artifact Test Output (opengl)
+      uses: actions/upload-artifact@v3
+      with:
         name: test-output-linux-opengl
         path: test-output-linux-opengl.zip
     - name: Run Test Suite (opengles)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,6 +116,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       ALSOFT_CONF: resources/alsoft.conf
+      DISPLAY: 0
     steps:
     - name: Update APT
       run: sudo apt-get update
@@ -138,10 +139,13 @@ jobs:
         mv love12/love-*.AppImage love12/love12.AppImage
         ls love12
         chmod +x love12/love12.AppImage
+    - name: Start xvfb
+      run: |
+        Xvfb :99 -screen 0, 360x240x24 &
+        echo "XVFBPID=$!" >> $GITHUB_ENV
     - name: Run Test Suite (opengl)
       run: |
-        export DISPLAY=0
-        xvfb-run --server-args="-screen 0, 360x240x24" love12/love12.AppImage main.lua 
+        love12/love12.AppImage main.lua 
     - name: Love Test Report (opengl)
       uses: ellraiser/love-test-report@main
       with:
@@ -159,8 +163,7 @@ jobs:
     - name: Run Test Suite (opengles)
       run: |
         export LOVE_GRAPHICS_USE_OPENGLES=1
-        export DISPLAY=1
-        xvfb-run --server-args="-screen 1, 360x240x24" love12/love12.AppImage main.lua 
+        love12/love12.AppImage main.lua 
     - name: Love Test Report (opengles)
       uses: ellraiser/love-test-report@main
       with:
@@ -175,3 +178,6 @@ jobs:
       with:
         name: test-output-linux-opengles
         path: test-output-linux-opengles.zip
+    - name: Stop xvfb
+      run: |
+        kill $XVFBPID

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
                                           libgl1-mesa-dev libdbus-1-dev libudev-dev libgles2-mesa-dev \
                                           libegl1-mesa-dev libibus-1.0-dev fcitx-libs-dev libsamplerate0-dev \
                                           libsndio-dev libwayland-dev libxkbcommon-dev libdrm-dev libgbm-dev \
-                                          libfuse2 wmctrl
+                                          libfuse2 wmctrl openbox
     - name: Checkout Repo
       uses: actions/checkout@v4
     - name: Download Love
@@ -139,10 +139,12 @@ jobs:
         mv love12/love-*.AppImage love12/love12.AppImage
         ls love12
         chmod +x love12/love12.AppImage
-    - name: Start xvfb
+    - name: Start xvfb and openbox
       run: |
         Xvfb :99 -screen 0, 360x240x24 &
         echo "XVFBPID=$!" >> $GITHUB_ENV
+        openbox &
+        echo "OPENBOXPID=$!" >> $GITHUB_ENV
     - name: Run Test Suite (opengl)
       run: |
         love12/love12.AppImage main.lua 
@@ -178,8 +180,9 @@ jobs:
       with:
         name: test-output-linux-opengles
         path: test-output-linux-opengles.zip
-    - name: Stop xvfb
-      # should always stop xvfb even if other steps failed
+    - name: Stop xvfb and openbox
+      # should always stop xvfb and openbox even if other steps failed
       if: always()
       run: |
         kill $XVFBPID
+        kill $OPENBOXPID

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,7 @@ jobs:
         chmod +x love12/love12.AppImage
     - name: Start xvfb and openbox
       run: |
-        Xvfb :99 -screen 0, 360x240x24 &
+        Xvfb :0 -screen 0, 360x240x24 &
         echo "XVFBPID=$!" >> $GITHUB_ENV
         openbox &
         echo "OPENBOXPID=$!" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,5 +179,7 @@ jobs:
         name: test-output-linux-opengles
         path: test-output-linux-opengles.zip
     - name: Stop xvfb
+      # should always stop xvfb even if other steps failed
+      if: always()
       run: |
         kill $XVFBPID

--- a/tests/window.lua
+++ b/tests/window.lua
@@ -187,9 +187,9 @@ love.test.window.isMinimized = function(test)
     test:assertEquals(false, love.window.isMinimized(), 'check window not minimized')
     -- try to minimize
     love.window.minimize()
-    test:setDelay(1)
+    test:setDelay(10)
   else
-    -- on linux minimize only gets recognised in the next frame
+    -- on linux minimize won't get recognized immediately, so wait a few frames
     test:assertEquals(true, love.window.isMinimized(), 'check window minimized')
     love.window.restore()
   end

--- a/tests/window.lua
+++ b/tests/window.lua
@@ -221,6 +221,7 @@ end
 -- love.window.maximize
 love.test.window.maximize = function(test)
   if test:isDelayed() == false then
+    test:assertEquals(false, love.window.isMaximized(), 'check window not maximized')
     -- check maximizing is set
     love.window.maximize()
     test:setDelay(10)
@@ -234,10 +235,16 @@ end
 
 -- love.window.minimize
 love.test.window.minimize = function(test)
-  -- check minimizing is set
-  love.window.minimize()
-  test:assertEquals(true, love.window.isMinimized(), 'check window minimized')
-  love.window.restore()
+  if test:isDelayed() == false then
+    test:assertEquals(false, love.window.isMinimized(), 'check window not minimized')
+    -- check minimizing is set
+    love.window.minimize()
+    test:setDelay(10)
+  else
+    -- on linux we need to wait a few frames
+    test:assertEquals(true, love.window.isMinimized(), 'check window maximized')
+    love.window.restore()
+  end
 end
 
 
@@ -249,6 +256,7 @@ end
 
 -- love.window.restore
 love.test.window.restore = function(test)
+  -- TODO: need to wait between action and check
   -- check minimized to start
   love.window.minimize()
   test:assertEquals(true, love.window.isMinimized(), 'check window minimized')

--- a/tests/window.lua
+++ b/tests/window.lua
@@ -169,6 +169,7 @@ end
 -- love.window.isMaximized
 love.test.window.isMaximized = function(test)
   if test:isDelayed() == false then
+    test:assertEquals(false, love.window.isMaximized(), 'check window not maximized')
     love.window.maximize()
     test:setDelay(10)
   else
@@ -181,12 +182,17 @@ end
 
 -- love.window.isMinimized
 love.test.window.isMinimized = function(test)
-  -- check not minimized to start
-  test:assertEquals(false, love.window.isMinimized(), 'check window not minimized')
-  -- try to minimize
-  love.window.minimize()
-  test:assertEquals(true, love.window.isMinimized(), 'check window minimized')
-  love.window.restore()
+  if test:isDelayed() == false then
+    -- check not minimized to start
+    test:assertEquals(false, love.window.isMinimized(), 'check window not minimized')
+    -- try to minimize
+    love.window.minimize()
+    test:setDelay(1)
+  else
+    -- on linux minimize only gets recognised in the next frame
+    test:assertEquals(true, love.window.isMinimized(), 'check window minimized')
+    love.window.restore()
+  end
 end
 
 


### PR DESCRIPTION
Just added a WM to the pipeline, then realized that all maximize and minimize tests need some delay and added that.

The `love.window.restore()` test doesn't pass because the current test delay system can't wait twice without making for very ugly code (I looked into trying to put coroutines in there, but your test calling code isn't exactly the most readable code I've ever seen so I assume you'll have an easier time implementing coroutines than me).

The `love.window.getPosition()` test passed before but doesn't now after i merged your newest changes, not sure what exactly broke it.